### PR TITLE
docs(typo): Removes old library name from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,18 @@ The `createAtom` creates a state that can be used by different components, and w
 
 First:
 
+```
+npm install --save atomic-state
+
+or
+
+yarn add --save atomic-state
+```
+
+Then
+
 ```jsx
-import { createAtom, useAtom } from "aesthetic-state";
+import { createAtom, useAtom } from "atomic-state";
 ```
 
 For example:
@@ -62,7 +72,7 @@ You have your app, your main component, you can use an atom in a similar way tha
 Take a look:
 
 ```jsx
-import { createAtom, useAtom } from "aesthetic-state";
+import { createAtom, useAtom } from "atomic-state";
 
 const EMAIL = createAtom({
   name: "email-state",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomic-state",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "State managment library for React and React Native apps",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Previous library name was 'aesthetic-state', replaced that with the new library name, 'atomic-state'